### PR TITLE
Add license to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "poetry-monorepo-dependency-plugin"
 version = "1.1.1.dev"
 description = "Poetry plugin that generates more easily consumable archives for projects in a monorepo structure with path dependencies on other Poetry projects"
 authors = ["Eric Konieczny <ekoniec1@gmail.com>"]
+license = "MIT"
 readme = "README.md"
 repository = "https://github.com/TechnologyBrewery/poetry-monorepo-dependency-plugin"
 


### PR DESCRIPTION
Adding a license to the resulting package that is pushed to PyPI helps users and automated tooling understand the terms under which a library can be used.