### PR TITLE
#17 add pathdep remover

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ building and publishing archives with local path dependencies to other Poetry pr
 poetry self add poetry-monorepo-dependency-plugin
 ```
 
-If you want to activate `poetry-monorepo-dependency-plugin` for all [build][poetry-build] and
-[publish][poetry-publish] command invocations, add the following to your project's `pyproject.toml`
+If you want to activate `poetry-monorepo-dependency-plugin` for all [build][poetry-build],
+[publish][poetry-publish], and [export][poetry-export] command invocations, add the following to your project's `pyproject.toml`
 that has path dependencies to other Poetry projects:
 
 ```toml
@@ -58,7 +58,7 @@ When generating `wheel` or `sdist` archives for the `spam` project through Poetr
 `Requires-Dist: ham @ ../ham` to `Requires-Dist: ham (==1.2.3)`
 
 Additionally, to address [path dependencies](https://python-poetry.org/docs/dependency-specification/#path-dependencies) not being portable, this plugin provides
-the ability to extend Poetry's [export][poetry-export] command usiusing the `export-without-path-deps` command. This command will exclude path dependencies from being written to intermediate `requirements.txt` exports. When installing the exported 
+the ability to extend Poetry's [export][poetry-export] command using the `export-without-path-deps` command. This command will exclude path dependencies from being written to intermediate `requirements.txt` export. When installing the exported 
 `requirements.txt` on another machine and/or Docker container local Paths dependencies can not be resolved and therefore can not 
 be installed so they are removed. 
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ When generating `wheel` or `sdist` archives for the `spam` project through Poetr
 `ham` project were declared as `ham = "1.2.3"`.  As a result, package metadata in archives for `spam` will shift from
 `Requires-Dist: ham @ ../ham` to `Requires-Dist: ham (==1.2.3)`
 
+Additionally, to address [path dependencies](https://python-poetry.org/docs/dependency-specification/#path-dependencies) not being portable, this plugin provides
+the ability to extend Poetry's [export][poetry-export] command usiusing the `export-without-path-deps` command. This command will exclude path dependencies from being written to intermediate `requirements.txt` exports. When installing the exported 
+`requirements.txt` on another machine and/or Docker container local Paths dependencies can not be resolved and therefore can not 
+be installed so they are removed. 
+
 ### Command line mode
 
 If you need greater control over when `poetry-monorepo-dependency-plugin` is activated, this plugin exposes new `build-rewrite-path-deps`
@@ -66,6 +71,11 @@ any configuration defined in the project's `pyproject.toml` `[tool.poetry-monore
 (other than `enable`) are exposed as command line options.  For example:
 ```commandline
 poetry build-rewrite-path-deps --version-pinning-strategy=semver
+```
+
+To generate a `requirements.txt` without path dependencies use the `export-without-path-deps`. For example:
+```commandline
+poetry export-without-path-deps -f requirements.txt --output requirements.txt
 ```
 
 ### Configuration
@@ -113,5 +123,6 @@ the package to PyPI.
 
 [poetry]: https://python-poetry.org/
 [poetry-build]: https://python-poetry.org/docs/cli/#build
+[poetry-export]: https://python-poetry.org/docs/cli/#export
 [poetry-publish]: https://python-poetry.org/docs/cli/#publish
 [mit_licence]: http://dan.mit-license.org/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/TechnologyBrewery/poetry-monorepo-dependency-pl
 [tool.poetry.dependencies]
 python = "^3.8"
 poetry = ">=1.6"
+poetry-plugin-export = ">=1.6.0"
 cleo = ">=2.0.1"
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/TechnologyBrewery/poetry-monorepo-dependency-pl
 [tool.poetry.dependencies]
 python = "^3.8"
 poetry = ">=1.6"
-poetry-plugin-export = ">=1.6.0"
+poetry-plugin-export = ">=1.5.0"
 cleo = ">=2.0.1"
 
 [tool.poetry.group.dev.dependencies]

--- a/src/poetry_monorepo_dependency_plugin/path_dependency_remover.py
+++ b/src/poetry_monorepo_dependency_plugin/path_dependency_remover.py
@@ -1,0 +1,53 @@
+import typing
+
+import cleo.io.io
+import cleo.io.outputs.output
+from poetry.core.pyproject.toml import PyProjectTOML
+from poetry.core.constraints.version import Version
+from poetry.core.packages.dependency import Dependency
+from poetry.core.packages.directory_dependency import DirectoryDependency
+from poetry.core.packages.dependency_group import DependencyGroup
+
+
+class PathDependencyRemover:
+    """
+    Exposes core functionality for gathering a pyproject.toml's path dependencies,
+    determining if they are Poetry projects, and if so, extracting the corresponding
+    dependency.
+    """
+
+    def update_dependency_group(
+        self,
+        io: cleo.io.io.IO,
+        pyproject: PyProjectTOML,
+        dependency_group: DependencyGroup,
+    ) -> None:
+        """
+        Removes all path dependencies to Poetry projects.
+
+        :param io: instance of Cleo IO that may be used for logging diagnostic output during
+        plugin execution
+        :param pyproject: encapsulates the pyproject.toml of the current project for which
+        path dependencies will be rewritten
+        :param dependency_group: specifies the dependency group from which to pin path
+        dependencies, this will usually be "main"
+        :return: none
+        """
+        io.write_line(
+            "Updating dependency constraints...",
+            verbosity=cleo.io.outputs.output.Verbosity.DEBUG,
+        )
+
+        for dependency in dependency_group.dependencies:
+            if not isinstance(
+                dependency,
+                DirectoryDependency,
+            ):
+                continue
+
+            io.write_line(
+                f"  • Removing {dependency.name} path dependency)",
+                verbosity=cleo.io.outputs.output.Verbosity.DEBUG,
+            )
+
+            dependency_group.remove_dependency(dependency.name)

--- a/src/poetry_monorepo_dependency_plugin/path_dependency_remover.py
+++ b/src/poetry_monorepo_dependency_plugin/path_dependency_remover.py
@@ -1,6 +1,6 @@
 import typing
 
-import cleo.io.io
+from cleo.io.io import IO as cleoIO
 import cleo.io.outputs.output
 from poetry.core.pyproject.toml import PyProjectTOML
 from poetry.core.constraints.version import Version
@@ -18,7 +18,7 @@ class PathDependencyRemover:
 
     def update_dependency_group(
         self,
-        io: cleo.io.io.IO,
+        io: cleoIO,
         pyproject: PyProjectTOML,
         dependency_group: DependencyGroup,
     ) -> None:

--- a/src/poetry_monorepo_dependency_plugin/plugin.py
+++ b/src/poetry_monorepo_dependency_plugin/plugin.py
@@ -13,63 +13,95 @@ from poetry.console.commands.build import BuildCommand
 from poetry.console.commands.publish import PublishCommand
 
 from .path_dependency_rewriter import PathDependencyRewriter
+from .path_dependency_remover import PathDependencyRemover
 
-_version_pinning_strategy = option(
-    "version-pinning-strategy",
-    "s",
-    "Stategy to use for rewriting any path dependencies to other Poetry projects "
-    "as versioned dependencies",
-    flag=False,
-    default="mixed",
-)
-"""
-Strategy by which path dependencies to other Poetry projects will be versioned in generated archives.  Valid options 
-include 'semver', 'exact', and 'mixed', with the default being 'mixed'.  Given a path dependency to a Poetry project 
-with version '1.2.3', the version of the dependency referenced in the generated archive is '^1.2.3' for 
-'semver' and '=1.2.3' for 'exact'.  
+# _version_pinning_strategy = option(
+#     "version-pinning-strategy",
+#     "s",
+#     "Stategy to use for rewriting any path dependencies to other Poetry projects "
+#     "as versioned dependencies",
+#     flag=False,
+#     default="mixed",
+# )
+# """
+# Strategy by which path dependencies to other Poetry projects will be versioned in generated archives.  Valid options
+# include 'semver', 'exact', and 'mixed', with the default being 'mixed'.  Given a path dependency to a Poetry project
+# with version '1.2.3', the version of the dependency referenced in the generated archive is '^1.2.3' for
+# 'semver' and '=1.2.3' for 'exact'.
 
-'mixed' mode switches versioning strategies based on whether or not the dependency
-Poetry project version is an in-flight development version or a release:
+# 'mixed' mode switches versioning strategies based on whether or not the dependency
+# Poetry project version is an in-flight development version or a release:
 
-If a development version (i.e. '1.2.3.dev456'), a variant of 'semver' is used that applies an upper-bound of the next 
-patch version (i.e. '>=1.2.3.dev,<1.2.4') 
-If a release version (i.e. '1.2.3'), 'exact' is applied (i.e. '=1.2.3').   
-"""
+# If a development version (i.e. '1.2.3.dev456'), a variant of 'semver' is used that applies an upper-bound of the next
+# patch version (i.e. '>=1.2.3.dev,<1.2.4')
+# If a release version (i.e. '1.2.3'), 'exact' is applied (i.e. '=1.2.3').
+# """
 
 
-class BuildWithVersionedPathDepsCommand(BuildCommand):
-    name = "build-rewrite-path-deps"
+# class BuildWithVersionedPathDepsCommand(BuildCommand):
+#     name = "build-rewrite-path-deps"
+#     description = (
+#         "Extends the 'build' command to generate archives in which path dependencies to "
+#         "other Poetry projects are re-written as versioned package dependencies that are "
+#         "resolvable via a private package repository source"
+#     )
+#     options = [*BuildCommand.options, _version_pinning_strategy]
+
+#     def handle(self) -> int:
+#         path_dependency_writer = PathDependencyRewriter(
+#             self.option("version-pinning-strategy")
+#         )
+#         path_dependency_writer.update_dependency_group(
+#             self.io, self.poetry.pyproject, self.poetry.package.dependency_group("main")
+#         )
+#         return super().handle()
+
+
+# class PublishWithVersionedPathDepsCommand(PublishCommand):
+#     name = "publish-rewrite-path-deps"
+#     description = (
+#         "Extends the 'publish' command to build (if specified via the --build option) and publish archives "
+#         "in which path dependencies to other Poetry projects are re-written as versioned package "
+#         "dependencies that are resolvable via a private package repository source"
+#     )
+#     options = [*PublishCommand.options, _version_pinning_strategy]
+
+#     def handle(self) -> int:
+#         path_dependency_writer = PathDependencyRewriter(
+#             self.option("version-pinning-strategy")
+#         )
+#         path_dependency_writer.update_dependency_group(
+#             self.io, self.poetry.pyproject, self.poetry.package.dependency_group("main")
+#         )
+#         return super().handle()
+
+
+class BuildWithoutPathDepsCommand(BuildCommand):
+    name = "build-without-path-deps"
     description = (
         "Extends the 'build' command to generate archives in which path dependencies to "
-        "other Poetry projects are re-written as versioned package dependencies that are "
-        "resolvable via a private package repository source"
+        "other Poetry projects are removed from package dependencies."
     )
-    options = [*BuildCommand.options, _version_pinning_strategy]
 
     def handle(self) -> int:
-        path_dependency_writer = PathDependencyRewriter(
-            self.option("version-pinning-strategy")
-        )
-        path_dependency_writer.update_dependency_group(
+        path_dependency_remover = PathDependencyRemover()
+        path_dependency_remover.update_dependency_group(
             self.io, self.poetry.pyproject, self.poetry.package.dependency_group("main")
         )
         return super().handle()
 
 
-class PublishWithVersionedPathDepsCommand(PublishCommand):
-    name = "publish-rewrite-path-deps"
+class PublishWithoutPathDepsCommand(PublishCommand):
+    name = "publish-without-path-deps"
     description = (
         "Extends the 'publish' command to build (if specified via the --build option) and publish archives "
-        "in which path dependencies to other Poetry projects are re-written as versioned package "
+        "in which path dependencies to other Poetry projects are removed from the package "
         "dependencies that are resolvable via a private package repository source"
     )
-    options = [*PublishCommand.options, _version_pinning_strategy]
 
     def handle(self) -> int:
-        path_dependency_writer = PathDependencyRewriter(
-            self.option("version-pinning-strategy")
-        )
-        path_dependency_writer.update_dependency_group(
+        path_dependency_remover = PathDependencyRemover()
+        path_dependency_remover.update_dependency_group(
             self.io, self.poetry.pyproject, self.poetry.package.dependency_group("main")
         )
         return super().handle()
@@ -87,25 +119,16 @@ class MonorepoDependencyPlugin(poetry.plugins.application_plugin.ApplicationPlug
 
     def activate(self, application: poetry.console.application.Application):
         application.command_loader.register_factory(
-            "build-rewrite-path-deps", lambda: BuildWithVersionedPathDepsCommand()
+            "build-without-path-deps", lambda: BuildWithoutPathDepsCommand()
         )
         application.command_loader.register_factory(
-            "publish-rewrite-path-deps", lambda: PublishWithVersionedPathDepsCommand()
+            "publish-without-path-deps", lambda: PublishWithoutPathDepsCommand()
         )
 
         try:
             local_poetry_proj_config = application.poetry.pyproject.data
         except Exception:
             # We're not in a valid Poetry project directory
-            return
-
-        plugin_config = _merge_dicts(
-            _default_plugin_config(), local_poetry_proj_config
-        )["tool"]["poetry-monorepo-dependency-plugin"]
-
-        # If the [tool.poetry-monorepo-dependency-plugin.enable] flag has not been set
-        # in pyproject.toml, do *not* intercept and modify build/publish commands
-        if not plugin_config["enable"]:
             return
 
         application.event_dispatcher.add_listener(
@@ -124,10 +147,8 @@ class MonorepoDependencyPlugin(poetry.plugins.application_plugin.ApplicationPlug
         if not isinstance(event.command, self.COMMANDS):
             return
 
-        path_dependency_writer = PathDependencyRewriter(
-            self.plugin_config["version-pinning-strategy"]
-        )
-        path_dependency_writer.update_dependency_group(
+        path_dependency_remover = PathDependencyRemover()
+        path_dependency_remover.update_dependency_group(
             event.io,
             self.poetry.pyproject,
             self.poetry.package.dependency_group("main"),

--- a/src/poetry_monorepo_dependency_plugin/plugin.py
+++ b/src/poetry_monorepo_dependency_plugin/plugin.py
@@ -15,65 +15,65 @@ from poetry.console.commands.publish import PublishCommand
 from .path_dependency_rewriter import PathDependencyRewriter
 from .path_dependency_remover import PathDependencyRemover
 
-# _version_pinning_strategy = option(
-#     "version-pinning-strategy",
-#     "s",
-#     "Stategy to use for rewriting any path dependencies to other Poetry projects "
-#     "as versioned dependencies",
-#     flag=False,
-#     default="mixed",
-# )
-# """
-# Strategy by which path dependencies to other Poetry projects will be versioned in generated archives.  Valid options
-# include 'semver', 'exact', and 'mixed', with the default being 'mixed'.  Given a path dependency to a Poetry project
-# with version '1.2.3', the version of the dependency referenced in the generated archive is '^1.2.3' for
-# 'semver' and '=1.2.3' for 'exact'.
+_version_pinning_strategy = option(
+    "version-pinning-strategy",
+    "s",
+    "Stategy to use for rewriting any path dependencies to other Poetry projects "
+    "as versioned dependencies",
+    flag=False,
+    default="mixed",
+)
+"""
+Strategy by which path dependencies to other Poetry projects will be versioned in generated archives.  Valid options 
+include 'semver', 'exact', and 'mixed', with the default being 'mixed'.  Given a path dependency to a Poetry project 
+with version '1.2.3', the version of the dependency referenced in the generated archive is '^1.2.3' for 
+'semver' and '=1.2.3' for 'exact'.  
 
-# 'mixed' mode switches versioning strategies based on whether or not the dependency
-# Poetry project version is an in-flight development version or a release:
+'mixed' mode switches versioning strategies based on whether or not the dependency
+Poetry project version is an in-flight development version or a release:
 
-# If a development version (i.e. '1.2.3.dev456'), a variant of 'semver' is used that applies an upper-bound of the next
-# patch version (i.e. '>=1.2.3.dev,<1.2.4')
-# If a release version (i.e. '1.2.3'), 'exact' is applied (i.e. '=1.2.3').
-# """
-
-
-# class BuildWithVersionedPathDepsCommand(BuildCommand):
-#     name = "build-rewrite-path-deps"
-#     description = (
-#         "Extends the 'build' command to generate archives in which path dependencies to "
-#         "other Poetry projects are re-written as versioned package dependencies that are "
-#         "resolvable via a private package repository source"
-#     )
-#     options = [*BuildCommand.options, _version_pinning_strategy]
-
-#     def handle(self) -> int:
-#         path_dependency_writer = PathDependencyRewriter(
-#             self.option("version-pinning-strategy")
-#         )
-#         path_dependency_writer.update_dependency_group(
-#             self.io, self.poetry.pyproject, self.poetry.package.dependency_group("main")
-#         )
-#         return super().handle()
+If a development version (i.e. '1.2.3.dev456'), a variant of 'semver' is used that applies an upper-bound of the next 
+patch version (i.e. '>=1.2.3.dev,<1.2.4') 
+If a release version (i.e. '1.2.3'), 'exact' is applied (i.e. '=1.2.3').   
+"""
 
 
-# class PublishWithVersionedPathDepsCommand(PublishCommand):
-#     name = "publish-rewrite-path-deps"
-#     description = (
-#         "Extends the 'publish' command to build (if specified via the --build option) and publish archives "
-#         "in which path dependencies to other Poetry projects are re-written as versioned package "
-#         "dependencies that are resolvable via a private package repository source"
-#     )
-#     options = [*PublishCommand.options, _version_pinning_strategy]
+class BuildWithVersionedPathDepsCommand(BuildCommand):
+    name = "build-rewrite-path-deps"
+    description = (
+        "Extends the 'build' command to generate archives in which path dependencies to "
+        "other Poetry projects are re-written as versioned package dependencies that are "
+        "resolvable via a private package repository source"
+    )
+    options = [*BuildCommand.options, _version_pinning_strategy]
 
-#     def handle(self) -> int:
-#         path_dependency_writer = PathDependencyRewriter(
-#             self.option("version-pinning-strategy")
-#         )
-#         path_dependency_writer.update_dependency_group(
-#             self.io, self.poetry.pyproject, self.poetry.package.dependency_group("main")
-#         )
-#         return super().handle()
+    def handle(self) -> int:
+        path_dependency_writer = PathDependencyRewriter(
+            self.option("version-pinning-strategy")
+        )
+        path_dependency_writer.update_dependency_group(
+            self.io, self.poetry.pyproject, self.poetry.package.dependency_group("main")
+        )
+        return super().handle()
+
+
+class PublishWithVersionedPathDepsCommand(PublishCommand):
+    name = "publish-rewrite-path-deps"
+    description = (
+        "Extends the 'publish' command to build (if specified via the --build option) and publish archives "
+        "in which path dependencies to other Poetry projects are re-written as versioned package "
+        "dependencies that are resolvable via a private package repository source"
+    )
+    options = [*PublishCommand.options, _version_pinning_strategy]
+
+    def handle(self) -> int:
+        path_dependency_writer = PathDependencyRewriter(
+            self.option("version-pinning-strategy")
+        )
+        path_dependency_writer.update_dependency_group(
+            self.io, self.poetry.pyproject, self.poetry.package.dependency_group("main")
+        )
+        return super().handle()
 
 
 class BuildWithoutPathDepsCommand(BuildCommand):

--- a/src/poetry_monorepo_dependency_plugin/plugin.py
+++ b/src/poetry_monorepo_dependency_plugin/plugin.py
@@ -11,8 +11,7 @@ import poetry.plugins.application_plugin
 from cleo.helpers import option
 from poetry.console.commands.build import BuildCommand
 from poetry.console.commands.publish import PublishCommand
-from poetry.console.commands.export import ExportCommand as BuiltInExportCommand
-from poetry_plugin_export.command import ExportCommand as PluginExportCommand
+from poetry_plugin_export.command import ExportCommand
 
 from .path_dependency_rewriter import PathDependencyRewriter
 from .path_dependency_remover import PathDependencyRemover
@@ -78,7 +77,7 @@ class PublishWithVersionedPathDepsCommand(PublishCommand):
         return super().handle()
 
 
-class ExportWithoutPathDepsCommand(PluginExportCommand):
+class ExportWithoutPathDepsCommand(ExportCommand):
     name = "export-without-path-deps"
     description = (
         "Extends the 'export' command to generate exports in which path dependencies to "
@@ -97,8 +96,7 @@ class MonorepoDependencyPlugin(poetry.plugins.application_plugin.ApplicationPlug
     COMMANDS = (
         BuildCommand,
         PublishCommand,
-        BuiltInExportCommand,
-        PluginExportCommand,
+        ExportCommand,
     )
 
     def __init__(self):
@@ -153,7 +151,7 @@ class MonorepoDependencyPlugin(poetry.plugins.application_plugin.ApplicationPlug
             verbosity=cleo.io.outputs.output.Verbosity.DEBUG,
         )
 
-        if isinstance(event.command, (BuiltInExportCommand, PluginExportCommand)):
+        if isinstance(event.command, ExportCommand):
             path_dependency_remover = PathDependencyRemover()
             path_dependency_remover.update_dependency_group(
                 event.io,

--- a/src/poetry_monorepo_dependency_plugin/plugin.py
+++ b/src/poetry_monorepo_dependency_plugin/plugin.py
@@ -150,7 +150,7 @@ class MonorepoDependencyPlugin(poetry.plugins.application_plugin.ApplicationPlug
 
         event.io.write_line(
             "Intercepting the command: " + str(event.command.__class__),
-            verbosity=cleo.io.outputs.output.Verbosity.NORMAL,
+            verbosity=cleo.io.outputs.output.Verbosity.DEBUG,
         )
 
         if isinstance(event.command, (BuiltInExportCommand, PluginExportCommand)):

--- a/tests/features/remove-path-dependencies.feature
+++ b/tests/features/remove-path-dependencies.feature
@@ -5,11 +5,11 @@ Feature: Remove path dependencies from Poetry projects
     When the project is built using the plugin's command-line mode
     Then the path dependencies for "<dependency name>" are no longer present in the pyproject.toml
     Examples:
-      | dependency name | version pinning strategy | pinned version     |
-      | spam            | mixed                    | >=1.2.3.dev,<1.2.4 |
-      | spam            | exact                    | 1.2.3.dev          |
-      | spam            | semver                   | ^1.2.3.dev         |
-      | ham             | mixed                    | 4.5.6              |
-      | ham             | exact                    | 4.5.6              |
-      | ham             | semver                   | ^4.5.6             |
-      | eggs            | mixed                    | >=1.0rc4,<1.0.1    |
+      | dependency name
+      | spam
+      | spam
+      | spam
+      | ham
+      | ham
+      | ham
+      | eggs

--- a/tests/features/remove-path-dependencies.feature
+++ b/tests/features/remove-path-dependencies.feature
@@ -2,8 +2,8 @@ Feature: Remove path dependencies from Poetry projects
 
   Scenario Outline: Remove project dependencies with paths 
     Given a project with a local path dependencies to other Poetry projects
-    When the project is built using the plugin's command-line mode
-    Then the path dependencies for "<dependency name>" are no longer present in the pyproject.toml
+    When the project is exported using the plugin's command-line mode
+    Then the path dependencies for "<dependency name>" are removed from poetry dependencies
     Examples:
       | dependency name
       | spam

--- a/tests/features/remove-path-dependencies.feature
+++ b/tests/features/remove-path-dependencies.feature
@@ -1,9 +1,9 @@
-Feature: Re-write path dependencies to Poetry projects as versioned package dependencies
+Feature: Remove path dependencies from Poetry projects
 
-  Scenario Outline: Re-written dependency version changes based on selected version pinning strategy
+  Scenario Outline: Remove project dependencies with paths 
     Given a project with a local path dependencies to other Poetry projects
-    When the project is built using the plugin's command-line mode with the configured "<version pinning strategy>"
-    Then the re-written dependency version for "<dependency name>" becomes "<pinned version>"
+    When the project is built using the plugin's command-line mode
+    Then the path dependencies for "<dependency name>" are no longer present in the pyproject.toml
     Examples:
       | dependency name | version pinning strategy | pinned version     |
       | spam            | mixed                    | >=1.2.3.dev,<1.2.4 |

--- a/tests/features/rewrite-path-dependencies.feature
+++ b/tests/features/rewrite-path-dependencies.feature
@@ -1,0 +1,15 @@
+Feature: Re-write path dependencies to Poetry projects as versioned package dependencies
+
+  Scenario Outline: Re-written dependency version changes based on selected version pinning strategy
+    Given a project with a local path dependencies to other Poetry projects
+    When the project is built using the plugin's command-line mode with the configured "<version pinning strategy>"
+    Then the re-written dependency version for "<dependency name>" becomes "<pinned version>"
+    Examples:
+      | dependency name | version pinning strategy | pinned version     |
+      | spam            | mixed                    | >=1.2.3.dev,<1.2.4 |
+      | spam            | exact                    | 1.2.3.dev          |
+      | spam            | semver                   | ^1.2.3.dev         |
+      | ham             | mixed                    | 4.5.6              |
+      | ham             | exact                    | 4.5.6              |
+      | ham             | semver                   | ^4.5.6             |
+      | eggs            | mixed                    | >=1.0rc4,<1.0.1    |

--- a/tests/features/steps/remove_path_dependencies_steps.py
+++ b/tests/features/steps/remove_path_dependencies_steps.py
@@ -12,7 +12,7 @@ from poetry_monorepo_dependency_plugin.path_dependency_remover import (
 )
 
 
-@when("the project is built using the plugin's command-line mode")
+@when("the project is exported using the plugin's command-line mode")
 def step_impl(context):
     path_dependency_remover = PathDependencyRemover()
     mock_io = unittest.mock.create_autospec(cleo.io.io.IO)
@@ -24,7 +24,7 @@ def step_impl(context):
 
 
 @then(
-    'the path dependencies for "{dependency_name}" are no longer present in the pyproject.toml'
+    'the path dependencies for "{dependency_name}" are removed from poetry dependencies'
 )
 def step_impl(context, dependency_name):
     mydependencies = context.project_with_local_deps.package.dependency_group(

--- a/tests/features/steps/remove_path_dependencies_steps.py
+++ b/tests/features/steps/remove_path_dependencies_steps.py
@@ -12,14 +12,6 @@ from poetry_monorepo_dependency_plugin.path_dependency_remover import (
 )
 
 
-@given("a project with a local path dependencies to other Poetry projects")
-def step_impl(context):
-    project_with_local_deps = poetry.core.factory.Factory().create_poetry(
-        Path(__file__).parents[2] / "resources/project-with-local-dependencies"
-    )
-    context.project_with_local_deps = project_with_local_deps
-
-
 @when("the project is built using the plugin's command-line mode")
 def step_impl(context):
     path_dependency_remover = PathDependencyRemover()

--- a/tests/features/steps/remove_path_dependencies_steps.py
+++ b/tests/features/steps/remove_path_dependencies_steps.py
@@ -1,0 +1,46 @@
+import unittest.mock
+import unittest
+from pathlib import Path
+
+import cleo.io.io
+import poetry.core.factory
+from behave import *
+import nose.tools as nt
+
+from poetry_monorepo_dependency_plugin.path_dependency_remover import (
+    PathDependencyRemover,
+)
+
+
+@given("a project with a local path dependencies to other Poetry projects")
+def step_impl(context):
+    project_with_local_deps = poetry.core.factory.Factory().create_poetry(
+        Path(__file__).parents[2] / "resources/project-with-local-dependencies"
+    )
+    context.project_with_local_deps = project_with_local_deps
+
+
+@when("the project is built using the plugin's command-line mode")
+def step_impl(context):
+    path_dependency_remover = PathDependencyRemover()
+    mock_io = unittest.mock.create_autospec(cleo.io.io.IO)
+    path_dependency_remover.update_dependency_group(
+        mock_io,
+        context.project_with_local_deps.pyproject,
+        context.project_with_local_deps.package.dependency_group("main"),
+    )
+
+
+@then(
+    'the path dependencies for "{dependency_name}" are no longer present in the pyproject.toml'
+)
+def step_impl(context, dependency_name):
+    mydependencies = context.project_with_local_deps.package.dependency_group(
+        "main"
+    ).dependencies
+
+    nt.assert_not_in(
+        dependency_name,
+        mydependencies,
+        f"Found the path dependency {dependency_name}",
+    )

--- a/tests/features/steps/rewrite_path_dependencies_steps.py
+++ b/tests/features/steps/rewrite_path_dependencies_steps.py
@@ -11,12 +11,12 @@ from poetry_monorepo_dependency_plugin.path_dependency_rewriter import (
 )
 
 
-@given("a project with a local path dependencies to other Poetry projects")
-def step_impl(context):
-    project_with_local_deps = poetry.core.factory.Factory().create_poetry(
-        Path(__file__).parents[2] / "resources/project-with-local-dependencies"
-    )
-    context.project_with_local_deps = project_with_local_deps
+# @given("a project with a local path dependencies to other Poetry projects")
+# def step_impl(context):
+#     project_with_local_deps = poetry.core.factory.Factory().create_poetry(
+#         Path(__file__).parents[2] / "resources/project-with-local-dependencies"
+#     )
+#     context.project_with_local_deps = project_with_local_deps
 
 
 @when(

--- a/tests/features/steps/rewrite_path_dependencies_steps.py
+++ b/tests/features/steps/rewrite_path_dependencies_steps.py
@@ -11,12 +11,12 @@ from poetry_monorepo_dependency_plugin.path_dependency_rewriter import (
 )
 
 
-# @given("a project with a local path dependencies to other Poetry projects")
-# def step_impl(context):
-#     project_with_local_deps = poetry.core.factory.Factory().create_poetry(
-#         Path(__file__).parents[2] / "resources/project-with-local-dependencies"
-#     )
-#     context.project_with_local_deps = project_with_local_deps
+@given("a project with a local path dependencies to other Poetry projects")
+def step_impl(context):
+    project_with_local_deps = poetry.core.factory.Factory().create_poetry(
+        Path(__file__).parents[2] / "resources/project-with-local-dependencies"
+    )
+    context.project_with_local_deps = project_with_local_deps
 
 
 @when(


### PR DESCRIPTION
Poetry path-based dependencies defined under the monorepo dependency group will fail to be resolved upon export on any machine that is not the one on which the original export was performed.

In order to prevent such dependency resolving failures, it is needed to extend poetry's export command such that any path-based dependencies are not included in the resultant requirements.txt.