### PR TITLE
Respect version pinning strategy passed by command line

### DIFF
--- a/src/poetry_monorepo_dependency_plugin/plugin.py
+++ b/src/poetry_monorepo_dependency_plugin/plugin.py
@@ -142,6 +142,9 @@ class MonorepoDependencyPlugin(poetry.plugins.application_plugin.ApplicationPlug
         event_name: str,
         dispatcher: cleo.events.event_dispatcher.EventDispatcher,
     ) -> None:
+        # Don't intercept our own custom commands (that inherit from commands we actually want to intercept)
+        if isinstance(event.command, (BuildWithVersionedPathDepsCommand, PublishWithVersionedPathDepsCommand)):
+            return
 
         if not isinstance(event.command, self.COMMANDS):
             return


### PR DESCRIPTION
Fixes duplicate executing of update_dependency_group, once with project config and once with provided command line option when using custom command, which results in the latter not having any effect anymore. Event listener should not intercept custom build and publish commands, only the standard ones, as for the custom commands the rewrite happens in the command itself

Can be reproduced with default project config and using `poetry build-rewrite-path-deps --version-pinning-strategy=semver` or `poetry build-rewrite-path-deps --version-pinning-strategy=exact` and observing that the actually strategy has not been applied