### PR TITLE
fix issue where extra information about packages is lost during build

### DIFF
--- a/src/poetry_monorepo_dependency_plugin/path_dependency_rewriter.py
+++ b/src/poetry_monorepo_dependency_plugin/path_dependency_rewriter.py
@@ -113,8 +113,15 @@ class PathDependencyRewriter:
                 ).next_patch()
                 pinned_version = f">={version},<{next_patch_version}"
 
-        return Dependency(
+        new_dependency = Dependency(
             name,
             pinned_version,
             groups=dependency.groups,
         )
+
+        # handle cases where dependency is part of an extra.
+        if dependency.in_extras:
+            new_dependency._optional = dependency._optional
+            new_dependency._in_extras = dependency._in_extras
+
+        return new_dependency

--- a/tests/features/rewrite-path-dependencies.feature
+++ b/tests/features/rewrite-path-dependencies.feature
@@ -3,13 +3,13 @@ Feature: Re-write path dependencies to Poetry projects as versioned package depe
   Scenario Outline: Re-written dependency version changes based on selected version pinning strategy
     Given a project with a local path dependencies to other Poetry projects
     When the project is built using the plugin's command-line mode with the configured "<version pinning strategy>"
-    Then the re-written dependency version for "<dependency name>" becomes "<pinned version>"
+    Then the re-written dependency version for "<dependency name>" becomes "<pinned version>", optional ("<optional>"), with extras: "<extras>"
     Examples:
-      | dependency name | version pinning strategy | pinned version     |
-      | spam            | mixed                    | >=1.2.3.dev,<1.2.4 |
-      | spam            | exact                    | 1.2.3.dev          |
-      | spam            | semver                   | ^1.2.3.dev         |
-      | ham             | mixed                    | 4.5.6              |
-      | ham             | exact                    | 4.5.6              |
-      | ham             | semver                   | ^4.5.6             |
-      | eggs            | mixed                    | >=1.0rc4,<1.0.1    |
+      | dependency name | version pinning strategy | pinned version     | extras      | optional |
+      | spam            | mixed                    | >=1.2.3.dev,<1.2.4 | ["testing"] | true     |
+      | spam            | exact                    | 1.2.3.dev          | ["testing"] | true     |
+      | spam            | semver                   | ^1.2.3.dev         | ["testing"] | true     |
+      | ham             | mixed                    | 4.5.6              | []          | false    |
+      | ham             | exact                    | 4.5.6              | []          | false    |
+      | ham             | semver                   | ^4.5.6             | []          | false    |
+      | eggs            | mixed                    | >=1.0rc4,<1.0.1    | []          | false    |

--- a/tests/features/steps/rewrite_path_dependencies_steps.py
+++ b/tests/features/steps/rewrite_path_dependencies_steps.py
@@ -1,5 +1,6 @@
 import unittest.mock
 from pathlib import Path
+import json
 
 import cleo.io.io
 import poetry.core.factory
@@ -33,9 +34,9 @@ def step_impl(context, version_pinning_strategy):
 
 
 @then(
-    'the re-written dependency version for "{dependency_name}" becomes "{pinned_version}"'
+    'the re-written dependency version for "{dependency_name}" becomes "{pinned_version}", optional ("{optional}"), with extras: "{extras}"'
 )
-def step_impl(context, dependency_name, pinned_version):
+def step_impl(context, dependency_name, pinned_version, optional, extras):
     rewritten_dependency = None
     for dependency in context.project_with_local_deps.package.dependency_group(
         "main"
@@ -53,4 +54,18 @@ def step_impl(context, dependency_name, pinned_version):
         pinned_version,
         f"Re-written pinned dependency version for {dependency_name} ({rewritten_dependency.pretty_constraint}) "
         f"did not equal the expected value of {pinned_version}",
+    )
+
+    nt.assert_equal(
+        rewritten_dependency._in_extras,
+        json.loads(extras),
+        f"Re-written extra dependency for {dependency_name} ({rewritten_dependency._in_extras}) "
+        f"did not equal the expected value of {extras}",
+    )
+
+    nt.assert_equal(
+        rewritten_dependency._optional,
+        json.loads(optional),
+        f"Re-written optional status for {dependency_name} ({rewritten_dependency._optional}) "
+        f"did not equal the expected value of {optional}",
     )

--- a/tests/resources/project-with-local-dependencies/pyproject.toml
+++ b/tests/resources/project-with-local-dependencies/pyproject.toml
@@ -6,6 +6,10 @@ authors = ["Some Developer <developer@email.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-spam = { path = "../spam", develop = true }
+spam = { path = "../spam", optional = true}
 ham = { path = "../ham", develop = true }
 eggs = { path = "../eggs", develop = true }
+
+
+[tool.poetry.extras]
+testing = ["spam"]


### PR DESCRIPTION
Fixes #29 by making sure the extra information is passed through on the PathDependencyRewriter. 