### PR TITLE
[#50] :arrow_up: upgrade to latest habushu

### DIFF
--- a/poetry.toml
+++ b/poetry.toml
@@ -1,5 +1,4 @@
 [virtualenvs]
-prefer-active-python = true
 in-project = true
 use-poetry-python = false
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     </scm>
 
     <properties>
-        <version.habushu.plugin>2.18.1</version.habushu.plugin>
+        <version.habushu.plugin>3.3.0</version.habushu.plugin>
     </properties>
 
     <build>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,10 @@ poetry-plugin-export = ">=1.5.0"
 cleo = ">=2.0.1"
 
 [tool.poetry.group.dev.dependencies]
-black = ">=24.8.0"
 behave = ">=1.2.6"
 pytest = ">=7.4.0"
-pylint = ">=3.2.7"
 kappa-maki = ">=1.0.2"
+ruff = "^0.14.9"
 
 [tool.poetry.plugins."poetry.application.plugin"]
 poetry-monorepo-dependency-plugin = "poetry_monorepo_dependency_plugin.plugin:MonorepoDependencyPlugin"

--- a/src/poetry_monorepo_dependency_plugin/path_dependency_remover.py
+++ b/src/poetry_monorepo_dependency_plugin/path_dependency_remover.py
@@ -1,12 +1,8 @@
-import typing
-
-from cleo.io.io import IO as cleoIO
 import cleo.io.outputs.output
-from poetry.core.pyproject.toml import PyProjectTOML
-from poetry.core.constraints.version import Version
-from poetry.core.packages.dependency import Dependency
-from poetry.core.packages.directory_dependency import DirectoryDependency
+from cleo.io.io import IO as cleoIO
 from poetry.core.packages.dependency_group import DependencyGroup
+from poetry.core.packages.directory_dependency import DirectoryDependency
+from poetry.core.pyproject.toml import PyProjectTOML
 
 
 class PathDependencyRemover:

--- a/src/poetry_monorepo_dependency_plugin/path_dependency_rewriter.py
+++ b/src/poetry_monorepo_dependency_plugin/path_dependency_rewriter.py
@@ -10,7 +10,7 @@ from poetry.core.packages.dependency_group import DependencyGroup
 
 
 def _validate_pinning_strategy(strategy):
-    if not strategy in ["mixed", "semver", "exact"]:
+    if strategy not in ["mixed", "semver", "exact"]:
         raise ValueError(f"Invalid version pinning strategy: {strategy}")
 
 

--- a/src/poetry_monorepo_dependency_plugin/plugin.py
+++ b/src/poetry_monorepo_dependency_plugin/plugin.py
@@ -142,7 +142,6 @@ class MonorepoDependencyPlugin(poetry.plugins.application_plugin.ApplicationPlug
         event_name: str,
         dispatcher: cleo.events.event_dispatcher.EventDispatcher,
     ) -> None:
-
         if not isinstance(event.command, self.COMMANDS):
             return
 

--- a/tests/features/steps/remove_path_dependencies_steps.py
+++ b/tests/features/steps/remove_path_dependencies_steps.py
@@ -10,7 +10,7 @@ from poetry_monorepo_dependency_plugin.path_dependency_remover import (
 
 
 @when("the project is exported using the plugin's command-line mode")
-def step_impl(context):
+def when_step_impl(context):
     path_dependency_remover = PathDependencyRemover()
     mock_io = unittest.mock.create_autospec(cleo.io.io.IO)
     path_dependency_remover.update_dependency_group(
@@ -23,11 +23,11 @@ def step_impl(context):
 @then(
     'the path dependencies for "{dependency_name}" are removed from poetry dependencies'
 )
-def step_impl(context, dependency_name):
+def then_step_impl(context, dependency_name):
     mydependencies = context.project_with_local_deps.package.dependency_group(
         "main"
     ).dependencies
 
-    assert (
-        dependency_name not in mydependencies
-    ), f"Found the path dependency {dependency_name}"
+    assert dependency_name not in mydependencies, (
+        f"Found the path dependency {dependency_name}"
+    )

--- a/tests/features/steps/rewrite_path_dependencies_steps.py
+++ b/tests/features/steps/rewrite_path_dependencies_steps.py
@@ -12,7 +12,7 @@ from poetry_monorepo_dependency_plugin.path_dependency_rewriter import (
 
 
 @given("a project with a local path dependencies to other Poetry projects")
-def step_impl(context):
+def given_step_impl(context):
     project_with_local_deps = poetry.core.factory.Factory().create_poetry(
         Path(__file__).parents[2] / "resources/project-with-local-dependencies"
     )
@@ -22,7 +22,7 @@ def step_impl(context):
 @when(
     'the project is built using the plugin\'s command-line mode with the configured "{version_pinning_strategy}"'
 )
-def step_impl(context, version_pinning_strategy):
+def when_step_impl(context, version_pinning_strategy):
     path_dependency_rewriter = PathDependencyRewriter(version_pinning_strategy)
     mock_io = unittest.mock.create_autospec(cleo.io.io.IO)
     path_dependency_rewriter.update_dependency_group(
@@ -35,7 +35,7 @@ def step_impl(context, version_pinning_strategy):
 @then(
     'the re-written dependency version for "{dependency_name}" becomes "{pinned_version}", optional ("{optional}"), with extras: "{extras}"'
 )
-def step_impl(context, dependency_name, pinned_version, optional, extras):
+def then_step_impl(context, dependency_name, pinned_version, optional, extras):
     rewritten_dependency = None
     for dependency in context.project_with_local_deps.package.dependency_group(
         "main"
@@ -44,9 +44,9 @@ def step_impl(context, dependency_name, pinned_version, optional, extras):
             rewritten_dependency = dependency
             break
 
-    assert (
-        rewritten_dependency is not None
-    ), f"Could not find dependency on {dependency_name}"
+    assert rewritten_dependency is not None, (
+        f"Could not find dependency on {dependency_name}"
+    )
 
     assert rewritten_dependency.pretty_constraint == pinned_version, (
         f"Re-written pinned dependency version for {dependency_name} ({rewritten_dependency.pretty_constraint}) "


### PR DESCRIPTION
## Summary by Sourcery

Update tooling and style to align with the latest Habushu and associated Python tooling expectations.

Enhancements:
- Rename Behave step implementations for clearer semantics and consistency with step types.
- Clean up imports and minor style issues in path dependency management modules to satisfy updated linters.
- Simplify event listener implementation by removing an unnecessary blank line.

Build:
- Upgrade Habushu Maven plugin version to 3.3.0.
- Adjust Poetry project configuration, including dev dependencies and virtualenv settings, to match the new tooling stack (replace Black/Pylint with Ruff and tweak virtualenv options).

Tests:
- Rename Behave step function definitions and reformat assertions in feature step files for improved readability and compatibility with updated tooling.