### PR TITLE
[#52] :arrow_up: remove EOL and unaccessible versions of python

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.technologybrewery</groupId>
         <artifactId>parent</artifactId>
-        <version>14</version>
+        <version>15</version>
     </parent>
 
     <groupId>org.technologybrewery</groupId>
@@ -47,7 +47,7 @@
     </scm>
 
     <properties>
-        <version.habushu.plugin>3.3.0</version.habushu.plugin>
+        <version.habushu.plugin>3.4.0</version.habushu.plugin>
     </properties>
 
     <build>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,16 +3,16 @@ repository = "https://github.com/TechnologyBrewery/poetry-monorepo-dependency-pl
 
 [project]
 name = "poetry-monorepo-dependency-plugin"
-version = "1.3.2.dev"
+version = "1.3.2.dev0"
 description = "Poetry plugin that generates more easily consumable archives for projects in a monorepo structure with path dependencies on other Poetry projects"
 authors = [{name = "Eric Konieczny", email = "ekoniec1@gmail.com"}]
 license = "MIT"
-requires-python = ">=3.8,<4"
+requires-python = ">=3.10,<4"
 dynamic = ["version", "dependencies"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-poetry = ">=1.6"
+poetry = ">=2.0"
 poetry-plugin-export = ">=1.5.0"
 cleo = ">=2.0.1"
 

--- a/tests/features/steps/rewrite_path_dependencies_steps.py
+++ b/tests/features/steps/rewrite_path_dependencies_steps.py
@@ -1,10 +1,10 @@
+import json
 import unittest.mock
 from pathlib import Path
-import json
 
 import cleo.io.io
 import poetry.core.factory
-from behave import given, when, then  # pylint: disable=no-name-in-module
+from behave import given, when, then
 
 from poetry_monorepo_dependency_plugin.path_dependency_rewriter import (
     PathDependencyRewriter,


### PR DESCRIPTION
## Summary by Sourcery

Update Python and tooling compatibility requirements to drop unsupported versions and align with newer dependencies.

Enhancements:
- Raise minimum supported Python version to 3.10 and require Poetry 2.x for the plugin.
- Bump Maven parent POM to version 15 and update Habushu plugin to 3.4.0.

Build:
- Refresh Maven parent and Habushu plugin versions to current releases.