### PR TITLE
[#54] :green_heart: build correct branch on PRs

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -10,9 +10,15 @@ name: Build poetry-monorepo-dependency-plugin
 
 on:
     push:
-        branches: [ "dev" ]
-    pull_request_target:
-        branches: [ "dev" ]
+        branches: ["dev"]
+    pull_request:
+        branches: ["dev"]
+    workflow_dispatch:
+        inputs:
+            target_branch:
+                description: 'Branch to build (leave empty to build the workflow branch)'
+                required: false
+                type: string
 
 jobs:
     build:
@@ -21,6 +27,11 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
+              with:
+                  # For PRs: checkout the source branch, not the merge commit
+                  # For workflow_dispatch: use target_branch input if provided, otherwise the workflow branch
+                  # For push: checkout the pushed ref
+                  ref: ${{ github.event_name == 'pull_request' && github.head_ref || (github.event_name == 'workflow_dispatch' && github.event.inputs.target_branch) || github.ref }}
 
             - name: Install Python # use direct install rather than pyenv for CI for large speed improvement
               uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary by Sourcery

Update the Maven GitHub Actions workflow to build from the correct branch for pull requests and support manually triggered builds with an optional target branch input.

CI:
- Switch the workflow trigger from pull_request_target to pull_request for dev branch builds.
- Add a workflow_dispatch trigger with an optional target_branch input and use it to control the checkout ref in CI runs.