### PR TITLE
[#30] :bug: respect version pinning strategy passed by command line

### DIFF
--- a/src/poetry_monorepo_dependency_plugin/plugin.py
+++ b/src/poetry_monorepo_dependency_plugin/plugin.py
@@ -93,10 +93,19 @@ class ExportWithoutPathDepsCommand(ExportCommand):
 
 
 class MonorepoDependencyPlugin(poetry.plugins.application_plugin.ApplicationPlugin):
+    # Standard Poetry commands that this plugin intercepts when enabled
     COMMANDS = (
         BuildCommand,
         PublishCommand,
         ExportCommand,
+    )
+
+    # Custom commands provided by this plugin that handle their own rewriting
+    # and should not be intercepted by the event listener
+    CUSTOM_COMMANDS = (
+        BuildWithVersionedPathDepsCommand,
+        PublishWithVersionedPathDepsCommand,
+        ExportWithoutPathDepsCommand,
     )
 
     def __init__(self):
@@ -142,6 +151,10 @@ class MonorepoDependencyPlugin(poetry.plugins.application_plugin.ApplicationPlug
         event_name: str,
         dispatcher: cleo.events.event_dispatcher.EventDispatcher,
     ) -> None:
+        # Don't intercept our own custom commands (that handle their own rewriting)
+        if isinstance(event.command, self.CUSTOM_COMMANDS):
+            return
+
         if not isinstance(event.command, self.COMMANDS):
             return
 

--- a/tests/features/remove-path-dependencies.feature
+++ b/tests/features/remove-path-dependencies.feature
@@ -1,15 +1,11 @@
 Feature: Remove path dependencies from Poetry projects
 
-  Scenario Outline: Remove project dependencies with paths 
+  Scenario Outline: Remove project dependencies with paths
     Given a project with a local path dependencies to other Poetry projects
     When the project is exported using the plugin's command-line mode
     Then the path dependencies for "<dependency name>" are removed from poetry dependencies
     Examples:
-      | dependency name
-      | spam
-      | spam
-      | spam
-      | ham
-      | ham
-      | ham
-      | eggs
+      | dependency name |
+      | spam            |
+      | ham             |
+      | eggs            |

--- a/tests/features/respect-cli-version-pinning-strategy.feature
+++ b/tests/features/respect-cli-version-pinning-strategy.feature
@@ -1,0 +1,42 @@
+Feature: Respect command-line version pinning strategy for custom commands
+
+  The plugin provides custom commands (build-rewrite-path-deps, publish-rewrite-path-deps)
+  that accept a --version-pinning-strategy option. When the plugin is enabled in
+  pyproject.toml, the event listener should NOT intercept these custom commands,
+  allowing the command-line strategy to take effect.
+
+  Scenario: Event listener skips custom build command
+    Given a plugin instance with an enabled configuration
+    And a mock BuildWithVersionedPathDepsCommand event
+    When the event listener processes the event
+    Then the event listener should return early without modifying dependencies
+
+  Scenario: Event listener skips custom publish command
+    Given a plugin instance with an enabled configuration
+    And a mock PublishWithVersionedPathDepsCommand event
+    When the event listener processes the event
+    Then the event listener should return early without modifying dependencies
+
+  Scenario: Event listener still intercepts standard build command
+    Given a plugin instance with an enabled configuration
+    And a mock standard BuildCommand event
+    When the event listener processes the event
+    Then the event listener should intercept and modify dependencies
+
+  Scenario: Event listener still intercepts standard publish command
+    Given a plugin instance with an enabled configuration
+    And a mock standard PublishCommand event
+    When the event listener processes the event
+    Then the event listener should intercept and modify dependencies
+
+  Scenario: Event listener skips custom export command
+    Given a plugin instance with an enabled configuration
+    And a mock ExportWithoutPathDepsCommand event
+    When the event listener processes the event
+    Then the event listener should return early without modifying dependencies
+
+  Scenario: Event listener still intercepts standard export command
+    Given a plugin instance with an enabled configuration
+    And a mock standard ExportCommand event
+    When the event listener processes the event
+    Then the event listener should intercept and remove path dependencies

--- a/tests/features/steps/remove_path_dependencies_steps.py
+++ b/tests/features/steps/remove_path_dependencies_steps.py
@@ -1,8 +1,7 @@
 import unittest.mock
-import unittest
 
 import cleo.io.io
-from behave import when, then  # pylint: disable=no-name-in-module
+from behave import when, then
 
 from poetry_monorepo_dependency_plugin.path_dependency_remover import (
     PathDependencyRemover,
@@ -28,6 +27,7 @@ def then_step_impl(context, dependency_name):
         "main"
     ).dependencies
 
-    assert dependency_name not in mydependencies, (
+    dependency_names = [dep.name for dep in mydependencies]
+    assert dependency_name not in dependency_names, (
         f"Found the path dependency {dependency_name}"
     )

--- a/tests/features/steps/respect_cli_version_pinning_strategy_steps.py
+++ b/tests/features/steps/respect_cli_version_pinning_strategy_steps.py
@@ -1,0 +1,177 @@
+import unittest.mock
+from pathlib import Path
+
+import cleo.events.console_command_event
+import cleo.events.event_dispatcher
+import cleo.io.io
+import poetry.core.factory
+from behave import given, when, then
+from poetry.console.commands.build import BuildCommand
+from poetry.console.commands.publish import PublishCommand
+from poetry_plugin_export.command import ExportCommand
+
+from poetry_monorepo_dependency_plugin.plugin import (
+    MonorepoDependencyPlugin,
+    BuildWithVersionedPathDepsCommand,
+    PublishWithVersionedPathDepsCommand,
+    ExportWithoutPathDepsCommand,
+)
+
+
+# Concrete stub classes for testing isinstance checks
+# These are minimal subclasses that work correctly with isinstance()
+class StubBuildWithVersionedPathDepsCommand(BuildWithVersionedPathDepsCommand):
+    """Test stub for BuildWithVersionedPathDepsCommand."""
+
+    def __init__(self):
+        pass  # Skip parent __init__ to avoid Poetry dependencies
+
+
+class StubPublishWithVersionedPathDepsCommand(PublishWithVersionedPathDepsCommand):
+    """Test stub for PublishWithVersionedPathDepsCommand."""
+
+    def __init__(self):
+        pass
+
+
+class StubExportWithoutPathDepsCommand(ExportWithoutPathDepsCommand):
+    """Test stub for ExportWithoutPathDepsCommand."""
+
+    def __init__(self):
+        pass
+
+
+class StubBuildCommand(BuildCommand):
+    """Test stub for standard BuildCommand."""
+
+    def __init__(self):
+        pass
+
+
+class StubPublishCommand(PublishCommand):
+    """Test stub for standard PublishCommand."""
+
+    def __init__(self):
+        pass
+
+
+class StubExportCommand(ExportCommand):
+    """Test stub for standard ExportCommand."""
+
+    def __init__(self):
+        pass
+
+
+@given("a plugin instance with an enabled configuration")
+def given_plugin_with_enabled_config(context):
+    """Set up a plugin instance with enabled configuration."""
+    plugin = MonorepoDependencyPlugin()
+
+    # Load test project
+    project_with_local_deps = poetry.core.factory.Factory().create_poetry(
+        Path(__file__).parents[2] / "resources/project-with-local-dependencies"
+    )
+
+    plugin.poetry = project_with_local_deps
+    plugin.plugin_config = {
+        "enable": True,
+        "version-pinning-strategy": "mixed",
+    }
+
+    context.plugin = plugin
+    context.project_with_local_deps = project_with_local_deps
+
+
+@given("a mock BuildWithVersionedPathDepsCommand event")
+def given_mock_build_custom_command_event(context):
+    """Create a mock event with BuildWithVersionedPathDepsCommand."""
+    context.mock_event = _create_mock_event(StubBuildWithVersionedPathDepsCommand())
+
+
+@given("a mock PublishWithVersionedPathDepsCommand event")
+def given_mock_publish_custom_command_event(context):
+    """Create a mock event with PublishWithVersionedPathDepsCommand."""
+    context.mock_event = _create_mock_event(StubPublishWithVersionedPathDepsCommand())
+
+
+@given("a mock ExportWithoutPathDepsCommand event")
+def given_mock_export_custom_command_event(context):
+    """Create a mock event with ExportWithoutPathDepsCommand."""
+    context.mock_event = _create_mock_event(StubExportWithoutPathDepsCommand())
+
+
+@given("a mock standard BuildCommand event")
+def given_mock_standard_build_command_event(context):
+    """Create a mock event with standard BuildCommand."""
+    context.mock_event = _create_mock_event(StubBuildCommand())
+
+
+@given("a mock standard PublishCommand event")
+def given_mock_standard_publish_command_event(context):
+    """Create a mock event with standard PublishCommand."""
+    context.mock_event = _create_mock_event(StubPublishCommand())
+
+
+@given("a mock standard ExportCommand event")
+def given_mock_standard_export_command_event(context):
+    """Create a mock event with standard ExportCommand."""
+    context.mock_event = _create_mock_event(StubExportCommand())
+
+
+@when("the event listener processes the event")
+def when_event_listener_processes_event(context):
+    """Call the event listener with the mock event."""
+    mock_dispatcher = unittest.mock.create_autospec(
+        cleo.events.event_dispatcher.EventDispatcher
+    )
+
+    # Track if PathDependencyRewriter or PathDependencyRemover was called
+    with (
+        unittest.mock.patch(
+            "poetry_monorepo_dependency_plugin.plugin.PathDependencyRewriter"
+        ) as mock_rewriter,
+        unittest.mock.patch(
+            "poetry_monorepo_dependency_plugin.plugin.PathDependencyRemover"
+        ) as mock_remover,
+    ):
+        context.plugin.event_listener(
+            context.mock_event,
+            "console.command",
+            mock_dispatcher,
+        )
+        context.rewriter_called = mock_rewriter.called
+        context.remover_called = mock_remover.called
+
+
+@then("the event listener should return early without modifying dependencies")
+def then_event_listener_returns_early(context):
+    """Verify the event listener did not modify dependencies."""
+    assert not context.rewriter_called and not context.remover_called, (
+        "Neither PathDependencyRewriter nor PathDependencyRemover should have been called for custom commands"
+    )
+
+
+@then("the event listener should intercept and modify dependencies")
+def then_event_listener_intercepts(context):
+    """Verify the event listener intercepted and modified dependencies."""
+    assert context.rewriter_called, (
+        "PathDependencyRewriter should have been called for standard commands"
+    )
+
+
+@then("the event listener should intercept and remove path dependencies")
+def then_event_listener_removes_deps(context):
+    """Verify the event listener intercepted and removed path dependencies."""
+    assert context.remover_called, (
+        "PathDependencyRemover should have been called for standard export command"
+    )
+
+
+def _create_mock_event(command):
+    """Helper to create a mock ConsoleCommandEvent with a real command instance."""
+    mock_event = unittest.mock.create_autospec(
+        cleo.events.console_command_event.ConsoleCommandEvent
+    )
+    mock_event.command = command
+    mock_event.io = unittest.mock.create_autospec(cleo.io.io.IO)
+    return mock_event


### PR DESCRIPTION
Respect version pinning strategy passed by command line

Fixes duplicate executing of update_dependency_group, once with project config and once with provided command line option when using custom command, which results in the latter not having any effect anymore. Event listener should not intercept custom build and publish commands, only the standard ones, as for the custom commands the rewrite happens in the command itself

## Summary by Sourcery

Ensure the plugin’s event listener does not intercept its own custom commands so that command-line version pinning strategy is respected while still handling standard Poetry commands.

Bug Fixes:
- Prevent duplicate dependency group updates by skipping interception for the plugin’s custom build, publish, and export commands when the listener runs.

Tests:
- Add behavior-driven tests verifying the event listener skips custom commands but continues to intercept standard build, publish, and export commands, and tighten path dependency removal assertions.