### PR TITLE
[#59] :green_heart: remove poetry caching to prevent failures due to …

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -38,15 +38,7 @@ jobs:
               with:
                 python-version: '3.12.9'
 
-            - name: Load cached Poetry installation
-              id: cached-poetry
-              uses: actions/cache@v4
-              with:
-                path: ~/.local
-                key: poetry-0  # increment to reset cache
-
             - name: Install Poetry
-              if: steps.cached-poetry.outputs.cache-hit != 'true'
               uses: snok/install-poetry@v1
 
             - name: Set up JDK 17


### PR DESCRIPTION
…plugin info missing

## Summary by Sourcery

CI:
- Simplify the Maven GitHub Actions workflow by removing Poetry caching and always installing Poetry without using the cache.